### PR TITLE
Changed loading of countries.json to use require()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-const fs = require('fs'); 
 const fuzz = require('fuzzball');
 function CLM() {
     var clm = {};
-    var rawdata = fs.readFileSync(__dirname+'/countries.json');
-    var countries = JSON.parse(rawdata);
+    var countries = require('./countries.json');
 
     var countryByAlpha2Code = {};
     var countryByAlpha3Code = {};


### PR DESCRIPTION
In order to use this module in a setting like an AWS Lambda function, fs.readFileSync() doesn't work so well. Because it is just loading a .json file we can use require() instead. Tested on node versions 8 - 14.