### PR TITLE
remove unnecessary console log

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ function CLM() {
     var clm = {};
 
     var countries; 
-    console.log(process.env.CLM_MODE);
 
     if(process && process.env && process.env.CLM_MODE == 'INTL') {
         countries = require('./countries-intl.json');


### PR DESCRIPTION
It breaks the usage in the browser since null checks are missing

(issue #15 )