### PR TITLE
Fix/protect against prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,133 +30,139 @@ function CLM() {
         }
     }
 
+    Object.freeze(countryByAlpha2Code)
+    Object.freeze(countryByAlpha3Code)
+    Object.freeze(countryByNumericCode)
+    Object.freeze(countryByName)
+    Object.freeze(countryNames)
+
     clm.getAllCountries = function(){
         return countries;
     }
 
     /* get values by alpha2 */
     clm.getAlpha3ByAlpha2 = function(alpha2) {
-        if(countryByAlpha2Code[alpha2])
+        if (countryByAlpha2Code.hasOwnProperty(alpha2))
             return countryByAlpha2Code[alpha2].alpha3;
         else 
             return undefined;
     }; 
 
     clm.getLocaleByAlpha2 = function(alpha2) {
-        if(countryByAlpha2Code[alpha2])
+        if (countryByAlpha2Code.hasOwnProperty(alpha2))
             return countryByAlpha2Code[alpha2].default_locale;
         else 
             return undefined;
     };
 
     clm.getCountryNameByAlpha2 = function(alpha2) {
-        if(countryByAlpha2Code[alpha2])
+        if (countryByAlpha2Code.hasOwnProperty(alpha2))
             return countryByAlpha2Code[alpha2].name;
         else 
             return undefined; 
     };
 
     clm.getNumericByAlpha2 = function(alpha2) {
-        if(countryByAlpha2Code[alpha2])
+        if (countryByAlpha2Code.hasOwnProperty(alpha2))
             return countryByAlpha2Code[alpha2].numeric;
         else 
             return undefined; 
     };
     
     clm.getCurrencyByAlpha2 = function(alpha2) {
-        if(countryByAlpha2Code[alpha2])
+        if (countryByAlpha2Code.hasOwnProperty(alpha2))
             return countryByAlpha2Code[alpha2].currency;
         else 
             return undefined; 
     }; 
 
     clm.getCountryByAlpha2 = function(alpha2) {
-        return countryByAlpha2Code[alpha2];
+        return countryByAlpha2Code.hasOwnProperty(alpha2) ? countryByAlpha2Code[alpha2] : undefined;
     }
 
     /* get values by alpha3 */
     clm.getAlpha2ByAlpha3 = function(alpha3) {
-        if(countryByAlpha3Code[alpha3])
+        if (countryByAlpha3Code.hasOwnProperty(alpha3))
             return countryByAlpha3Code[alpha3].alpha2;
         else 
             return undefined;
     }; 
 
     clm.getLocaleByAlpha3 = function(alpha3) {
-        if(countryByAlpha3Code[alpha3])
+        if (countryByAlpha3Code.hasOwnProperty(alpha3))
             return countryByAlpha3Code[alpha3].default_locale;
         else 
             return undefined;
     };
 
     clm.getCountryNameByAlpha3 = function(alpha3) {
-        if(countryByAlpha3Code[alpha3])
+        if (countryByAlpha3Code.hasOwnProperty(alpha3))
             return countryByAlpha3Code[alpha3].name;
         else 
             return undefined; 
     };
 
     clm.getNumericByAlpha3 = function(alpha3) {
-        if(countryByAlpha3Code[alpha3])
+        if (countryByAlpha3Code.hasOwnProperty(alpha3))
             return countryByAlpha3Code[alpha3].numeric;
         else 
             return undefined; 
     };    
 
     clm.getCurrencyByAlpha3 = function(alpha3) {
-        if(countryByAlpha3Code[alpha3])
+        if (countryByAlpha3Code.hasOwnProperty(alpha3))
             return countryByAlpha3Code[alpha3].currency;
         else 
             return undefined; 
     }; 
 
     clm.getCountryByAlpha3 = function(alpha3) {
-        return countryByAlpha3Code[alpha3];
+        return countryByAlpha3Code.hasOwnProperty(alpha3) ? countryByAlpha3Code[alpha3] : undefined;
     }
 
     /* get values by numeric */
     clm.getAlpha2ByNumeric = function(numeric) {
-        if(countryByNumericCode[numeric])
+        if (countryByNumericCode.hasOwnProperty(numeric))
             return countryByNumericCode[numeric].alpha2;
         else 
             return undefined;
     }; 
 
     clm.getAlpha3ByNumeric = function(numeric) {
-        if(countryByNumericCode[numeric])
+        if (countryByNumericCode.hasOwnProperty(numeric))
             return countryByNumericCode[numeric].alpha3;
         else 
             return undefined;
     };     
 
     clm.getLocaleByNumeric = function(numeric) {
-        if(countryByNumericCode[numeric])
+        if (countryByNumericCode.hasOwnProperty(numeric))
             return countryByNumericCode[numeric].default_locale;
         else 
             return undefined;
     };
 
     clm.getCountryNameByNumeric = function(numeric) {
-        if(countryByNumericCode[numeric])
+        if (countryByNumericCode.hasOwnProperty(numeric))
             return countryByNumericCode[numeric].name;
         else 
             return undefined; 
     };    
 
     clm.getCurrencyByNumeric = function(numeric) {
-        if(countryByNumericCode[numeric])
+        if (countryByNumericCode.hasOwnProperty(numeric))
             return countryByNumericCode[numeric].currency;
         else 
             return undefined;
     };
 
     clm.getCountryByNumeric = function(numeric) {
-        return countryByNumericCode[numeric];
+        return countryByNumericCode.hasOwnProperty(numeric) ? countryByNumericCode[numeric] : undefined;
     };
 
     /* get values by country name */
     clm.getAlpha2ByName = function(name, fuzzy) {
-        if(countryByName[name]) {
+        if(countryByName.hasOwnProperty(name)) {
             return countryByName[name].alpha2;
         } else if(fuzzy) {
             let match = getClosestMatch(name);
@@ -168,7 +174,7 @@ function CLM() {
     }; 
 
     clm.getAlpha3ByName = function(name, fuzzy) {
-        if(countryByName[name]) {
+        if(countryByName.hasOwnProperty(name)) {
             return countryByName[name].alpha3;
         } else if(fuzzy) {
             let match = getClosestMatch(name);
@@ -181,7 +187,7 @@ function CLM() {
     };     
 
     clm.getLocaleByName = function(name, fuzzy) {
-        if(countryByName[name]) {
+        if(countryByName.hasOwnProperty(name)) {
             return countryByName[name].default_locale;
         } else if(fuzzy) {
             let match = getClosestMatch(name);
@@ -194,7 +200,7 @@ function CLM() {
     };
 
     clm.getNumericByName = function(name, fuzzy) {
-        if(countryByName[name]) {
+        if(countryByName.hasOwnProperty(name)) {
             return countryByName[name].numeric;
         } else if(fuzzy) {
             let match = getClosestMatch(name);
@@ -206,7 +212,7 @@ function CLM() {
     };    
 
     clm.getCurrencyByName = function(name, fuzzy) {
-        if(countryByName[name]) {
+        if(countryByName.hasOwnProperty(name)) {
             return countryByName[name].currency;
         } else if(fuzzy) {
             let match = getClosestMatch(name);
@@ -220,7 +226,7 @@ function CLM() {
 
     clm.getCountryByName = function(name, fuzzy) {
         
-        if(countryByName[name]) {
+        if(countryByName.hasOwnProperty(name)) {
             return countryByName[name];
         } else if(fuzzy) {
             let match = getClosestMatch(name);

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -262,4 +262,20 @@ describe('CountryLanguageMap', function(){
     let result = clm.getCurrencyByAlpha2("KR");
     expect(result).to.equal("KRW");
   });
+
+  it("getCountryByName should be unable to read the prototype", function () {
+    expect(clm.getCountryByName("__proto__")).to.equal(undefined)
+  })
+
+  it("getCountryByAlpha2 should be unable to read the prototype", function () {
+    expect(clm.getCountryByAlpha2("__proto__")).to.equal(undefined)
+  })
+
+  it("getCountryByAlpha3 should be unable to read the prototype", function () {
+    expect(clm.getCountryByAlpha3("__proto__")).to.equal(undefined)
+  })
+
+  it("getCountryByNumeric should be unable to read the prototype", function () {
+    expect(clm.getCountryByNumeric("__proto__")).to.equal(undefined)
+  })
 })


### PR DESCRIPTION
This adds defenses against Prototype Pollution

These methods all exposed access to the underlying prototype, which can be used to cause vulnerabilities in applications that use this library. You can read more about this exploit class here https://portswigger.net/daily-swig/prototype-pollution-the-dangerous-and-underrated-vulnerability-impacting-javascript-applications

This commit implements two mitigations:
    1) All property checks are replaced with [obj.hasOwnProperty](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty). This limits all reads to only be on properties that were directly set on the objects, such as the countries.
    2) Freezes all internal read-only objects. This makes it so that even if they, or their prototype, are exposed they can't be changed in a way that affects the application. You can read more here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze

To verify for yourself that the prototype was accessible, you can run the tests in https://github.com/atnmorrison/country-locale-map/pull/40/commits/95fee54fc8e1a469c379ed10f30d77cd04bef098 without the changes in the other commits